### PR TITLE
#3: <input> background is #FFF when autofilled/autocompleted

### DIFF
--- a/src/assets/css/index.scss
+++ b/src/assets/css/index.scss
@@ -463,3 +463,12 @@ footer {
   }
 
 }
+
+/* Change autocomplete styles in WebKit */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0px 1000px #fff inset;
+  box-shadow: 0 0 0px 1000px #fff inset;
+  transition: background-color 5000s ease-in-out 0s;
+}


### PR DESCRIPTION
Sign-off by Nishit Prasad: [prasad.nishit0@gmail.com](mailto:prasad.nishit0@gmail.com)

This PR fixes #3 

**Description**
The browser autofill style can be overridden via WebKit. Hence, added webkit autofill override specific to input fields.

![ScreenRecord](https://user-images.githubusercontent.com/64563418/123768966-6e53de80-d8e6-11eb-82d9-3128fa2cb235.gif)
